### PR TITLE
Better to raise a BAD_CRC flag so that app can have a chance to handl…

### DIFF
--- a/generator/C/include_v2.0/mavlink_helpers.h
+++ b/generator/C/include_v2.0/mavlink_helpers.h
@@ -980,7 +980,7 @@ MAVLINK_HELPER uint8_t mavlink_parse_char(uint8_t chan, uint8_t c, mavlink_messa
 		    rxmsg->len = 0;
 		    mavlink_start_checksum(rxmsg);
 	    }
-	    return 0;
+	    return MAVLINK_FRAMING_BAD_CRC;
     }
     return msg_received;
 }


### PR DESCRIPTION
…e the case more precisely.

Raise a BAD_CRC to distinguish from INCOMPLETE packet so that app can tell the difference and handle it separately.
