### PR TITLE
Restore null pointer detection in parser.

### DIFF
--- a/generator/C/include_v2.0/mavlink_helpers.h
+++ b/generator/C/include_v2.0/mavlink_helpers.h
@@ -822,14 +822,19 @@ MAVLINK_HELPER uint8_t mavlink_frame_char_buffer(mavlink_message_t* rxmsg,
 		status->packet_rx_success_count++;
 	}
 
-	r_message->len = rxmsg->len; // Provide visibility on how far we are into current msg
-	r_mavlink_status->parse_state = status->parse_state;
-	r_mavlink_status->packet_idx = status->packet_idx;
-	r_mavlink_status->current_rx_seq = status->current_rx_seq+1;
-	r_mavlink_status->packet_rx_success_count = status->packet_rx_success_count;
-	r_mavlink_status->packet_rx_drop_count = status->parse_error;
-	r_mavlink_status->flags = status->flags;
-	status->parse_error = 0;
+        if (r_message!=NULL) {
+            r_message->len = rxmsg->len; // Provide visibility on how far we are into current msg
+        }
+
+        if (r_mavlink_status!=NULL) {
+           r_mavlink_status->parse_state = status->parse_state;
+	   r_mavlink_status->packet_idx = status->packet_idx;
+	   r_mavlink_status->current_rx_seq = status->current_rx_seq+1;
+	   r_mavlink_status->packet_rx_success_count = status->packet_rx_success_count;
+	   r_mavlink_status->packet_rx_drop_count = status->parse_error;
+	   r_mavlink_status->flags = status->flags;
+        }
+        status->parse_error = 0;
 
 	if (status->msg_received == MAVLINK_FRAMING_BAD_CRC) {
 		/*
@@ -839,7 +844,9 @@ MAVLINK_HELPER uint8_t mavlink_frame_char_buffer(mavlink_message_t* rxmsg,
 		  mavlink_msg_to_send_buffer() won't overwrite the
 		  checksum
 		 */
+            if (r_message!=NULL) {
 		r_message->checksum = rxmsg->ck[0] | (rxmsg->ck[1]<<8);
+            }
 	}
 
 	return status->msg_received;


### PR DESCRIPTION
Removal of null pointer detection in v2.0 suppressed convenience invocation to parser like:

`mavlink_parse_char(MAVLINK_BACKHAUL, *tp, NULL, NULL);`

for constrained system. Better to restore.


