### PR TITLE
Remove 0.9 support from gen_js.sh

### DIFF
--- a/generator/gen_js.sh
+++ b/generator/gen_js.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-for protocol in 0.9 1.0; do
+for protocol in 1.0; do
  for xml in ../../message_definitions/v$protocol/*.xml; do
      base=$(basename $xml .xml)
      mkdir -p javascript/implementations/mavlink_${base}_v${protocol}


### PR DESCRIPTION
0.9 is no longer used anywhere. As part of https://github.com/mavlink/mavlink/pull/835 am removing the messages from 0.9 tree. This change allows the system to build when the messages are gone.